### PR TITLE
Add missing `data_type` to enum selection query

### DIFF
--- a/src/mysql-client.ts
+++ b/src/mysql-client.ts
@@ -93,7 +93,8 @@ export class MySQL {
       this.connection,
       sql`SELECT
          column_name as column_name,
-         column_type as column_type
+         column_type as column_type,
+         data_type as data_type
       FROM information_schema.columns 
       WHERE data_type IN ('enum', 'set')
       AND table_schema = ${this.schema()}


### PR DESCRIPTION
`EnumRecord` type has 3 properties: `column_name`, `column_type`, `data_type` but query that is mapping it's result to it didn't previously select `data_type`.